### PR TITLE
copy npm dir on bootstrap

### DIFF
--- a/runtime/bootstrap
+++ b/runtime/bootstrap
@@ -238,6 +238,7 @@ cp -R /opt/.deno_dir/gen/. /tmp/deno_dir/gen &> /dev/null \
 cp -R $LAMBDA_TASK_ROOT/$DENO_DIR/gen/. /tmp/deno_dir/gen &> /dev/null \
  && cp -R $LAMBDA_TASK_ROOT/$DENO_DIR/deps/. /tmp/deno_dir/deps &> /dev/null \
  && cp -R $LAMBDA_TASK_ROOT/$DENO_DIR/gen/. /tmp/deno_dir/gen &> /dev/null \
+ && cp -R $LAMBDA_TASK_ROOT/$DENO_DIR/npm/. /tmp/deno_dir/npm &> /dev/null \
  && cp -R $LAMBDA_TASK_ROOT/$DENO_DIR/LAMBDA_TASK_ROOT/. /tmp/deno_dir/gen/file$LAMBDA_TASK_ROOT &> /dev/null \
  || expr match "$HANDLER_FILE" ".*bundle.js" &> /dev/null \
  || echo "warn: unable to import '$DENO_DIR/' as DENO_DIR"


### PR DESCRIPTION
I have the same problem as #214 and found the following steps to solve it.

I set `DENO_DIR` to pwd and run `deno cache`. then I found `npm` dir was created.
but it's not being copied by bootstrap.

I think this is due to the new cache directory added by npm support in deno v1.28. (this is uncertain.)
I referenced pull request #217 by @buwon.

thanks.